### PR TITLE
Add support for a hash fragment to be appended to a url.

### DIFF
--- a/src/DeSmart/Pagination/Paginator.php
+++ b/src/DeSmart/Pagination/Paginator.php
@@ -151,9 +151,9 @@ class Paginator extends BasePaginator {
 
     // allow adding hash fragments to url
     $fragment = $this->buildFragment();
-    $generatedRoute = $this->urlGenerator->route($this->routeConfig['name'], $parameters, $absolute, $this->routeConfig['instance']);
+    $generated_route = $this->urlGenerator->route($this->routeConfig['name'], $parameters, $absolute, $this->routeConfig['instance']);
 
-    return $generatedRoute.$fragment;
+    return $generated_route.$fragment;
   }
 
   /**

--- a/src/DeSmart/Pagination/Paginator.php
+++ b/src/DeSmart/Pagination/Paginator.php
@@ -149,7 +149,11 @@ class Paginator extends BasePaginator {
     $parameters[$this->factory->getPageName()] = $page;
     $absolute = (null === $this->routeConfig['absolute']) ? true : $this->routeConfig['absolute'];
 
-    return $this->urlGenerator->route($this->routeConfig['name'], $parameters, $absolute, $this->routeConfig['instance']);
+    // allow adding hash fragments to url
+    $fragment = $this->buildFragment();
+    $generatedRoute = $this->urlGenerator->route($this->routeConfig['name'], $parameters, $absolute, $this->routeConfig['instance']);
+
+    return $generatedRoute.$fragment;
   }
 
   /**

--- a/tests/PaginatorTest.php
+++ b/tests/PaginatorTest.php
@@ -172,4 +172,17 @@ class PaginatorTest extends PHPUnit_Framework_TestCase {
     $this->assertFalse($p->canShowLastPage());
   }
 
+  public function testCanAddFragmentWithRouteConfig() {
+    $generator = m::mock('Illuminate\Routing\UrlGenerator');
+    $p = new Paginator($env = m::mock('DeSmart\Pagination\Factory'), array('foo', 'bar', 'baz'), 3, 2);
+    $p->fragment('test');
+    $p->setUrlGenerator($generator);
+    $p->withoutQuery();
+    $env->shouldReceive('getRequest')->never();
+    $env->shouldReceive('getPageName')->andReturn('page');
+    $generator->shouldReceive('route')->once()->with($name = 'test.route', array('page' => 1), true, null);
+    $p->route($name);
+    $this->assertEquals('#test', $p->getUrl(1));
+  }
+
 }


### PR DESCRIPTION
The Laravel pagination allows you to add #hash to pagination links like 

```
$something->fragment('foo')->links();
```

This is needed for things like multiple paginations in tabs ect... 
